### PR TITLE
Converted long_description to use codecs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
+import codecs
 from setuptools import setup
 
 try:
     import multiprocessing
 except ImportError:
     pass
+
+with codecs.open('README.rst', encoding='utf-8') as readme:
+     long_description = readme.read()
 
 setup(
     name="django-settings-export",
@@ -12,7 +16,7 @@ setup(
     author_email="jakub@roztocil.co",
     description='This Django app allows you to export'
                 ' certain settings to your templates.',
-    long_description=open('README.rst').read().strip(),
+    long_description=long_description,
     license='BSD',
     url='https://github.com/jkbrzt/django-settings-export',
     classifiers=[


### PR DESCRIPTION
On a system with python 3 and the default encoding not set to UTF-8, this fails to install from pypi with:
```
 Running setup.py (path:/tmp/pip_build_root/django-settings-export/setup.py) egg_info for package django-settings-export
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/django-settings-export/setup.py", line 15, in <module>
        long_description=open('README.rst').read().strip(),
      File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 835: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/django-settings-export/setup.py", line 15, in <module>

    long_description=open('README.rst').read().strip(),

  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode

    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 835: ordinal not in range(128)
```

This should resolve that issue.