### PR TITLE
Added ability to set the name of the context variable to something besides "settings".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ See also the bundled
 `demo app <https://github.com/jkbrzt/django-settings-export/tree/master/demo>`_.
 
 If you wish to change the name of the context variable to something besides
-``settings``, add ``SETTINGS_EXPORT_NAME = 'settings_name'`` to your settings.py.
+``settings``, add ``SETTINGS_EXPORT_VARIABLE_NAME = 'settings_name'`` to your settings.py.
 This is useful when some other plugin is already adding ``settings`` to your
 template contexts.
 

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,11 @@ via ``settings.<KEY>``:
 See also the bundled
 `demo app <https://github.com/jkbrzt/django-settings-export/tree/master/demo>`_.
 
+If you wish to change the name of the context variable to something besides
+``settings``, add ``SETTINGS_EXPORT_NAME = 'settings_name'`` to your settings.py.
+This is useful when some other plugin is already adding ``settings`` to your
+template contexts.
+
 Development
 ===========
 

--- a/demo/templates/ok_rename.html
+++ b/demo/templates/ok_rename.html
@@ -1,0 +1,4 @@
+<pre>
+django_settings.FOO: {{ django_settings.FOO }}
+django_settings.BAR: {{ django_settings.BAR }}
+</pre>

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -26,17 +26,11 @@ class TestSettingsExportContextProcessor(TestCase):
         self.assertContains(r, 'settings.BAR: bar')
 
     def test_export_ok_with_renamed_variable(self):
-        from django.conf import settings
-        settings.SETTINGS_EXPORT_VARIABLE_NAME = 'django_settings'
-        # This is a try/finally to make sure that a failure here doesn't break
-        # the settings for other tests.
-        try:
+        with self.settings(SETTINGS_EXPORT_VARIABLE_NAME='django_settings'):
             r = self.client.get('/rename')
             self.assertEqual(r.status_code, 200)
             self.assertContains(r, 'django_settings.FOO: foo')
             self.assertContains(r, 'django_settings.BAR: bar')
-        finally:
-            del settings.SETTINGS_EXPORT_VARIABLE_NAME
 
     def test_unexported_setting(self):
         with self.assertRaises(UnexportedSettingError):

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -25,6 +25,19 @@ class TestSettingsExportContextProcessor(TestCase):
         self.assertContains(r, 'settings.FOO: foo')
         self.assertContains(r, 'settings.BAR: bar')
 
+    def test_export_ok_with_renamed_variable(self):
+        from django.conf import settings
+        settings.SETTINGS_EXPORT_VARIABLE_NAME = 'django_settings'
+        # This is a try/finally to make sure that a failure here doesn't break
+        # the settings for other tests.
+        try:
+            r = self.client.get('/rename')
+            self.assertEqual(r.status_code, 200)
+            self.assertContains(r, 'django_settings.FOO: foo')
+            self.assertContains(r, 'django_settings.BAR: bar')
+        finally:
+            del settings.SETTINGS_EXPORT_VARIABLE_NAME
+
     def test_unexported_setting(self):
         with self.assertRaises(UnexportedSettingError):
             self.client.get('/error')

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -6,6 +6,7 @@ from . import views
 urlpatterns = patterns(
     '',
     ('^$', views.render_ok),
+    ('^rename$', views.render_ok_rename),
     ('^error$', views.render_error),
 )
 

--- a/demo/views.py
+++ b/demo/views.py
@@ -5,5 +5,9 @@ def render_ok(request):
     return render(request, 'ok.html')
 
 
+def render_ok_rename(request):
+    return render(request, 'ok_rename.html')
+
+
 def render_error(request):
     return render(request, 'error.html')

--- a/django_settings_export.py
+++ b/django_settings_export.py
@@ -8,7 +8,7 @@ from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-__version__ = '1.0.5'
+__version__ = '1.1.0'
 
 
 class SettingsExportError(ImproperlyConfigured):
@@ -25,12 +25,13 @@ class UnexportedSettingError(SettingsExportError):
 
 def settings_export(request):
     """
-    The template context processor that adds settings defined
-    in `settings.SETTINGS_EXPORT` to the context.
-
+    The template context processor that adds settings defined in
+    `settings.SETTINGS_EXPORT` (or whatever SETTINGS_EXPORT_NAME is set to)
+    to the context.
     """
+    settings_name = getattr(django_settings, 'SETTINGS_EXPORT_NAME', 'settings')
     return {
-        'settings': _get_exported_settings()
+        settings_name: _get_exported_settings()
     }
 
 

--- a/django_settings_export.py
+++ b/django_settings_export.py
@@ -26,12 +26,12 @@ class UnexportedSettingError(SettingsExportError):
 def settings_export(request):
     """
     The template context processor that adds settings defined in
-    `settings.SETTINGS_EXPORT` (or whatever SETTINGS_EXPORT_NAME is set to)
-    to the context.
+    `SETTINGS_EXPORT` to the context. If SETTINGS_EXPORT_VARIABLE_NAME is not
+    set, the context variable will be `settings`.
     """
-    settings_name = getattr(django_settings, 'SETTINGS_EXPORT_NAME', 'settings')
+    variable_name = getattr(django_settings, 'SETTINGS_EXPORT_VARIABLE_NAME', 'settings')
     return {
-        settings_name: _get_exported_settings()
+        variable_name: _get_exported_settings()
     }
 
 


### PR DESCRIPTION
I ran into this problem when using `django-settings-export` with Wagtail, since the `wagtail.contrib.settings` plugin also exports a name called `settings` to your template contexts. So I added the `SETTINGS_EXPORT_NAME` option.